### PR TITLE
Adding window_role property

### DIFF
--- a/i3ipc-glib/i3ipc-con.c
+++ b/i3ipc-glib/i3ipc-con.c
@@ -74,6 +74,7 @@ struct _i3ipcConPrivate {
   gboolean fullscreen_mode;
   gchar *type;
   gchar *window_class;
+  gchar *window_role;
   gchar *mark;
 
   i3ipcConnection *conn;
@@ -103,6 +104,7 @@ enum {
   PROP_FULLSCREEN_MODE,
   PROP_TYPE,
   PROP_WINDOW_CLASS,
+  PROP_WINDOW_ROLE,
   PROP_MARK,
 
   PROP_RECT,
@@ -184,6 +186,10 @@ static void i3ipc_con_get_property(GObject *object, guint property_id, GValue *v
       g_value_set_string(value, self->priv->window_class);
       break;
 
+    case PROP_WINDOW_ROLE:
+      g_value_set_string(value, self->priv->window_role);
+      break;
+
     case PROP_MARK:
       g_value_set_string(value, self->priv->mark);
       break;
@@ -251,6 +257,7 @@ static void i3ipc_con_finalize(GObject *gobject) {
   g_free(self->priv->border);
   g_free(self->priv->type);
   g_free(self->priv->window_class);
+  g_free(self->priv->window_role);
   g_free(self->priv->mark);
 
   g_object_unref(self->priv->conn);
@@ -373,6 +380,13 @@ static void i3ipc_con_class_init(i3ipcConClass *klass) {
         "", /* default */
         G_PARAM_READABLE);
 
+  obj_properties[PROP_WINDOW_ROLE] =
+    g_param_spec_string("window_role",
+        "Con window role",
+        "The role of the window according to WM_WINDOW_ROLE",
+        "", /* default */
+        G_PARAM_READABLE);
+
   obj_properties[PROP_MARK] =
     g_param_spec_string("mark",
         "Con mark",
@@ -486,6 +500,8 @@ i3ipcCon *i3ipc_con_new(i3ipcCon *parent, JsonObject *data, i3ipcConnection *con
 
     if (json_object_has_member(window_properties, "class"))
       con->priv->window_class = g_strdup(json_object_get_string_member(window_properties, "class"));
+    if (json_object_has_member(window_properties, "window_role"))
+      con->priv->window_role = g_strdup(json_object_get_string_member(window_properties, "window_role"));
   }
 
   if (json_object_has_member(data, "mark")) {


### PR DESCRIPTION
It is useful to have WM_WINDOW_ROLE property in a i3ipcCon. User can filter windows by this property (e. g. xfce4-terminal with unique --role argument or vim instances).