### PR TITLE
Fixing i3ipc_con_descendents memory leak

### DIFF
--- a/i3ipc-glib/i3ipc-con.c
+++ b/i3ipc-glib/i3ipc-con.c
@@ -656,8 +656,7 @@ GList *i3ipc_con_descendents(i3ipcCon *self) {
   g_list_foreach(self->priv->nodes, i3ipc_con_collect_descendents_func, retval);
   g_list_foreach(self->priv->floating_nodes, i3ipc_con_collect_descendents_func, retval);
 
-  /* XXX: I hope this doesn't leak */
-  retval = g_list_remove_link(retval, g_list_first(retval));
+  retval = g_list_delete_link(retval, g_list_first(retval));
 
   return retval;
 }


### PR DESCRIPTION
Fixes i3ipc_con_descendents memory leak. g_list_remove_link only removes node when g_list_delete_link also frees it.