### PR TITLE
Fix $includedir

### DIFF
--- a/i3ipc-glib/i3ipc-glib.pc.in
+++ b/i3ipc-glib/i3ipc-glib.pc.in
@@ -7,6 +7,6 @@ Name: i3ipc-GLib
 Description: i3ipc for GLib
 Version: @VERSION@
 Libs: -L${libdir} -li3ipc-glib-1.0
-Cflags: -I${includedir}/i3ipc-glib
+Cflags: -I${includedir}
 Requires: gobject-2.0
 Requires.private: json-glib-1.0 gio-2.0


### PR DESCRIPTION
```
$ pkg-config --libs --cflags i3ipc-glib-1.0
-pthread -I/home/orestis/Documents/programming/i3ipc-glib/install/include/i3ipc-glib -I/usr/include/json-glib-1.0 -I/usr/include/glib-2.0 -I/usr/lib/glib-2.0/include -L/home/orestis/Documents/programming/i3ipc-glib/install/lib -li3ipc-glib-1.0 -lgobject-2.0 -lglib-2.0

$ gcc -o example example.c $(pkg-config --libs --cflags i3ipc-glib-1.0)
example.c:2:10: fatal error: i3ipc-glib/i3ipc-glib.h: No such file or directory
 #include <i3ipc-glib/i3ipc-glib.h>
          ^~~~~~~~~~~~~~~~~~~~~~~~~
compilation terminated.
```